### PR TITLE
Change check for linux platform

### DIFF
--- a/ftd2xx/ftd2xx.py
+++ b/ftd2xx/ftd2xx.py
@@ -8,7 +8,7 @@ import sys
 
 if sys.platform == 'win32':
     import _ftd2xx as _ft
-elif sys.platform == 'linux2':
+elif sys.platform.startswith('linux'):
     import _ftd2xx_linux as _ft
 elif sys.platform == 'darwin':
     import _ftd2xx_darwin as _ft


### PR DESCRIPTION
Checking for linux platform was failing due to the 'linux2' string returned from sys.platform.
Update the check for running under linux to use the 'startswith' function of sys.platform.