### PR TITLE
Added getComPort method to FTD2XX class

### DIFF
--- a/ftd2xx/_ftd2xx.py
+++ b/ftd2xx/_ftd2xx.py
@@ -546,6 +546,12 @@ FT_GetDeviceInfo.argtypes = [FT_HANDLE, POINTER(FT_DEVICE), LPDWORD, PCHAR, PCHA
 FT_GetDeviceInfo.__doc__ = \
 """FT_STATUS FT_GetDeviceInfo(FT_HANDLE ftHandle, FT_DEVICE * lpftDevice, LPDWORD lpdwID, PCHAR SerialNumber, PCHAR Description, LPVOID Dummy)
 ftd2xx.h:596"""
+FT_GetComPortNumber = _libraries['ftd2xx.dll'].FT_GetComPortNumber
+FT_GetComPortNumber.restype = FT_STATUS
+# FT_GetComPortNumber(ftHandle, lplComPortNumber)
+FT_GetComPortNumber.argtypes = [FT_HANDLE, LPWORD]
+FT_GetDeviceInfo.__doc__ = \
+""""FT_STATUS FT_GetComPortNumber(FT_HANDLE ftHandle,  LPWORD lplComPortNumber)"""
 # ftd2xx.h 601
 FT_StopInTask = _libraries['ftd2xx.dll'].FT_StopInTask
 FT_StopInTask.restype = FT_STATUS

--- a/ftd2xx/ftd2xx.py
+++ b/ftd2xx/ftd2xx.py
@@ -313,6 +313,11 @@ class FTD2XX(object):
         return {'type': deviceType.value, 'id': deviceId.value,
                 'description': desc.value, 'serial': serial.value}
 
+    def getComPort(self):
+        comPort = _ft.WORD()
+        call_ft(_ft.FT_GetComPortNumber, self.handle, c.byref(comPort))
+        return comPort.value
+
     def stopInTask(self):
         call_ft(_ft.FT_StopInTask, self.handle)
         return None


### PR DESCRIPTION
in _ftd2xx.py, I was not sure what to put for the ftd2xx.h index. The header indices are commented out, so the change still functions properly, but that information is left out in this commit.